### PR TITLE
[codex] Add consented local object detection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "hologram",
       "dependencies": {
+        "@huggingface/transformers": "^4.2.0",
         "@tailwindcss/vite": "^4.1.13",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.4.0",
@@ -34,6 +35,8 @@
     },
   },
   "packages": {
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.9", "", { "os": "aix", "cpu": "ppc64" }, "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.25.9", "", { "os": "android", "cpu": "arm" }, "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ=="],
@@ -86,6 +89,62 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.9", "", { "os": "win32", "cpu": "x64" }, "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ=="],
 
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
+
+    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@4.2.0", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "sharp": "^0.34.5" } }, "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -101,6 +160,24 @@
     "@lucide/svelte": ["@lucide/svelte@0.544.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-9f9O6uxng2pLB01sxNySHduJN3HTl5p0HDu4H26VR51vhZfiMzyOMe9Mhof3XAk4l813eTtl+/DYRvGyoRR+yw=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.50.2", "", { "os": "android", "cpu": "arm" }, "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A=="],
 
@@ -226,9 +303,13 @@
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
+    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -242,13 +323,27 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
     "detect-libc": ["detect-libc@2.1.0", "", {}, "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "devalue": ["devalue@5.3.2", "", {}, "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
+
     "esbuild": ["esbuild@0.25.9", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.9", "@esbuild/android-arm": "0.25.9", "@esbuild/android-arm64": "0.25.9", "@esbuild/android-x64": "0.25.9", "@esbuild/darwin-arm64": "0.25.9", "@esbuild/darwin-x64": "0.25.9", "@esbuild/freebsd-arm64": "0.25.9", "@esbuild/freebsd-x64": "0.25.9", "@esbuild/linux-arm": "0.25.9", "@esbuild/linux-arm64": "0.25.9", "@esbuild/linux-ia32": "0.25.9", "@esbuild/linux-loong64": "0.25.9", "@esbuild/linux-mips64el": "0.25.9", "@esbuild/linux-ppc64": "0.25.9", "@esbuild/linux-riscv64": "0.25.9", "@esbuild/linux-s390x": "0.25.9", "@esbuild/linux-x64": "0.25.9", "@esbuild/netbsd-arm64": "0.25.9", "@esbuild/netbsd-x64": "0.25.9", "@esbuild/openbsd-arm64": "0.25.9", "@esbuild/openbsd-x64": "0.25.9", "@esbuild/openharmony-arm64": "0.25.9", "@esbuild/sunos-x64": "0.25.9", "@esbuild/win32-arm64": "0.25.9", "@esbuild/win32-ia32": "0.25.9", "@esbuild/win32-x64": "0.25.9" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
@@ -256,13 +351,27 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
     "jiti": ["jiti@2.5.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w=="],
+
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -290,7 +399,11 @@
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
@@ -306,11 +419,21 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pixelmatch": ["pixelmatch@7.1.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng=="],
+
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
@@ -320,17 +443,31 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "protobufjs": ["protobufjs@7.6.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
     "rollup": ["rollup@4.50.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.50.2", "@rollup/rollup-android-arm64": "4.50.2", "@rollup/rollup-darwin-arm64": "4.50.2", "@rollup/rollup-darwin-x64": "4.50.2", "@rollup/rollup-freebsd-arm64": "4.50.2", "@rollup/rollup-freebsd-x64": "4.50.2", "@rollup/rollup-linux-arm-gnueabihf": "4.50.2", "@rollup/rollup-linux-arm-musleabihf": "4.50.2", "@rollup/rollup-linux-arm64-gnu": "4.50.2", "@rollup/rollup-linux-arm64-musl": "4.50.2", "@rollup/rollup-linux-loong64-gnu": "4.50.2", "@rollup/rollup-linux-ppc64-gnu": "4.50.2", "@rollup/rollup-linux-riscv64-gnu": "4.50.2", "@rollup/rollup-linux-riscv64-musl": "4.50.2", "@rollup/rollup-linux-s390x-gnu": "4.50.2", "@rollup/rollup-linux-x64-gnu": "4.50.2", "@rollup/rollup-linux-x64-musl": "4.50.2", "@rollup/rollup-openharmony-arm64": "4.50.2", "@rollup/rollup-win32-arm64-msvc": "4.50.2", "@rollup/rollup-win32-ia32-msvc": "4.50.2", "@rollup/rollup-win32-x64-msvc": "4.50.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
+
     "set-cookie-parser": ["set-cookie-parser@2.7.1", "", {}, "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "svelte": ["svelte@5.38.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-UY+OhrWK7WI22bCZ00P/M3HtyWgwJPi9IxSRkoAE2MeAy6kl7ZlZWJZ8RaB+X4KD/G+wjis+cGVnVYaoqbzBqg=="],
 
@@ -350,7 +487,11 @@
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "tw-animate-css": ["tw-animate-css@1.3.8", "", {}, "sha512-Qrk3PZ7l7wUcGYhwZloqfkWCmaXZAoqjkdbIDvzfGshwGtexa/DAs9koXxIkrpEasyevandomzCBAV1Yyop5rw=="],
+
+    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
@@ -378,7 +519,11 @@
 
     "@types/pngjs/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
+
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@huggingface/transformers": "^4.2.0",
     "@tailwindcss/vite": "^4.1.13",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.4.0",

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,25 +1,130 @@
 import type { Photo, SmartCollection, VisualIndexEntry, VisualIndexLabel } from "./types.ts";
 
-const minConfidence = 0.58;
+const minConfidence = 0.55;
+
+const accentByKind: Record<SmartCollection["kind"], string> = {
+  memory: "from-rose-500 to-amber-400",
+  object: "from-sky-500 to-cyan-400",
+  scene: "from-emerald-500 to-teal-400",
+  visual: "from-violet-500 to-fuchsia-400",
+};
 
 function titleCaseLabel(label: string): string {
   return label.replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function photoDate(photo: Photo): Date {
+  return new Date(photo.exif.date_taken ?? photo.modified_at ?? photo.created_at);
+}
+
+function monthKey(photo: Photo): string {
+  const date = photoDate(photo);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function formatMonth(key: string): string {
+  const [year, month] = key.split("-").map(Number);
+  return new Intl.DateTimeFormat(undefined, { month: "long", year: "numeric" }).format(new Date(year, month - 1, 1));
+}
+
+function formatCount(count: number): string {
+  return `${count} ${count === 1 ? "photo" : "photos"}`;
+}
+
+function coverPhotoIds(photos: Photo[], entries: Record<string, VisualIndexEntry>): string[] {
+  return [...photos]
+    .sort((a, b) => {
+      const aScore = entries[a.id]?.labels[0]?.confidence ?? 0;
+      const bScore = entries[b.id]?.labels[0]?.confidence ?? 0;
+      return bScore - aScore;
+    })
+    .slice(0, 4)
+    .map((photo) => photo.id);
+}
+
 function pushCollection(
   collections: SmartCollection[],
   label: string,
-  kind: VisualIndexLabel["kind"],
+  kind: Exclude<VisualIndexLabel["kind"], "memory">,
   photos: Photo[],
   averageConfidence: number,
+  entries: Record<string, VisualIndexEntry>,
 ) {
   if (photos.length < 2) return;
+  const collectionKind: SmartCollection["kind"] = kind;
   collections.push({
-    id: `visual-${kind}-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+    id: `visual-${kind}-${slug(label)}`,
     name: titleCaseLabel(label),
-    kind,
-    detail: `${photos.length} photos / ${Math.round(averageConfidence * 100)}% average signal`,
+    kind: collectionKind,
+    label,
+    detail: `${formatCount(photos.length)} / ${Math.round(averageConfidence * 100)}% signal`,
     photo_ids: photos.map((photo) => photo.id),
+    cover_photo_ids: coverPhotoIds(photos, entries),
+    confidence: averageConfidence,
+    accent: accentByKind[collectionKind],
+  });
+}
+
+function dominantLabel(
+  photos: Photo[],
+  entries: Record<string, VisualIndexEntry>,
+): { label: string; confidence: number } | null {
+  const labels = new Map<string, { total: number; count: number }>();
+  for (const photo of photos) {
+    const entry = entries[photo.id];
+    if (!entry) continue;
+    for (const label of entry.labels) {
+      if (label.kind === "memory" || label.confidence < minConfidence) continue;
+      const current = labels.get(label.label) ?? { total: 0, count: 0 };
+      current.total += label.confidence;
+      current.count += 1;
+      labels.set(label.label, current);
+    }
+  }
+
+  const ranked = Array.from(labels.entries())
+    .map(([label, score]) => ({
+      label,
+      confidence: score.total / score.count,
+      count: score.count,
+    }))
+    .filter((item) => item.count >= 2)
+    .sort((a, b) => b.count - a.count || b.confidence - a.confidence);
+
+  return ranked[0] ?? null;
+}
+
+function buildMemoryCollections(
+  photos: Photo[],
+  entries: Record<string, VisualIndexEntry>,
+): SmartCollection[] {
+  const groups = new Map<string, Photo[]>();
+  for (const photo of photos) {
+    groups.set(monthKey(photo), [...(groups.get(monthKey(photo)) ?? []), photo]);
+  }
+
+  return Array.from(groups.entries()).flatMap(([key, items]) => {
+    if (items.length < 4) return [];
+    const dominant = dominantLabel(items, entries);
+    const month = formatMonth(key);
+    const name = dominant ? `${dominant.label} in ${month}` : month;
+    return [{
+      id: `memory-${slug(key)}-${slug(dominant?.label ?? "moments")}`,
+      name,
+      kind: "memory",
+      label: dominant?.label,
+      detail: dominant
+        ? `${formatCount(items.length)} / ${Math.round(dominant.confidence * 100)}% theme`
+        : formatCount(items.length),
+      photo_ids: items.map((photo) => photo.id),
+      cover_photo_ids: coverPhotoIds(items, entries),
+      confidence: dominant?.confidence ?? 0.5,
+      accent: accentByKind.memory,
+    } satisfies SmartCollection];
   });
 }
 
@@ -28,13 +133,13 @@ export function buildSmartCollections(
   visualIndex: Record<string, VisualIndexEntry>,
 ): SmartCollection[] {
   const photosById = new Map(photos.map((photo) => [photo.id, photo]));
-  const buckets = new Map<string, { kind: VisualIndexLabel["kind"]; photos: Photo[]; confidence: number }>();
+  const buckets = new Map<string, { kind: Exclude<VisualIndexLabel["kind"], "memory">; photos: Photo[]; confidence: number }>();
 
   for (const [photoId, entry] of Object.entries(visualIndex)) {
     const photo = photosById.get(photoId);
     if (!photo) continue;
     for (const label of entry.labels) {
-      if (label.confidence < minConfidence) continue;
+      if (label.kind === "memory" || label.confidence < minConfidence) continue;
       const key = `${label.kind}:${label.label}`;
       const bucket = buckets.get(key) ?? { kind: label.kind, photos: [], confidence: 0 };
       bucket.photos.push(photo);
@@ -43,21 +148,24 @@ export function buildSmartCollections(
     }
   }
 
-  const collections: SmartCollection[] = [];
+  const collections: SmartCollection[] = buildMemoryCollections(photos, visualIndex);
   for (const [key, bucket] of buckets) {
     const label = key.split(":").slice(1).join(":");
-    pushCollection(collections, label, bucket.kind, bucket.photos, bucket.confidence / bucket.photos.length);
+    pushCollection(collections, label, bucket.kind, bucket.photos, bucket.confidence / bucket.photos.length, visualIndex);
   }
 
-  const kindRank: Record<VisualIndexLabel["kind"], number> = {
-    object: 0,
-    scene: 1,
-    visual: 2,
+  const kindRank: Record<SmartCollection["kind"], number> = {
+    memory: 0,
+    object: 1,
+    scene: 2,
+    visual: 3,
   };
 
   return collections.sort((a, b) => {
     const kindDelta = kindRank[a.kind] - kindRank[b.kind];
     if (kindDelta !== 0) return kindDelta;
+    const confidenceDelta = (b.confidence ?? 0) - (a.confidence ?? 0);
+    if (Math.abs(confidenceDelta) > 0.01) return confidenceDelta;
     const countDelta = b.photo_ids.length - a.photo_ids.length;
     if (countDelta !== 0) return countDelta;
     return a.name.localeCompare(b.name);

--- a/src/lib/components/DetectionDebugModal.svelte
+++ b/src/lib/components/DetectionDebugModal.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+    import { convertFileSrc } from "@tauri-apps/api/core";
+    import { Bug, ImageOff, ScanSearch, X } from "@lucide/svelte";
+    import type { ObjectDetectionBox, Photo, SmartCollection, VisualIndexEntry, VisualIndexLabel } from "../types.ts";
+
+    interface Props {
+        collection: SmartCollection;
+        photos: Photo[];
+        visualIndex: Record<string, VisualIndexEntry>;
+        onClose: () => void;
+    }
+
+    let { collection, photos, visualIndex, onClose }: Props = $props();
+    let activePhotoId = $state(collection.photo_ids[0] ?? "");
+
+    const collectionPhotos = $derived(collection.photo_ids.map((id) => photos.find((photo) => photo.id === id)).filter(Boolean) as Photo[]);
+    const activePhoto = $derived(collectionPhotos.find((photo) => photo.id === activePhotoId) ?? collectionPhotos[0]);
+    const activeEntry = $derived(activePhoto ? visualIndex[activePhoto.id] : undefined);
+    const activeBoxes = $derived(filteredBoxes(activeEntry?.detections ?? [], collection));
+    const activeLabels = $derived(filteredLabels(activeEntry?.labels ?? [], collection));
+
+    function previewSrc(photo: Photo | undefined): string {
+        if (!photo) return "";
+        if (photo.thumbnail) {
+            const mime = photo.thumbnail.startsWith("iVBOR") ? "image/png" : "image/jpeg";
+            return `data:${mime};base64,${photo.thumbnail}`;
+        }
+        if (["JPEG", "JPG", "PNG", "WEBP", "GIF"].includes(photo.file_type.toUpperCase())) {
+            try {
+                return convertFileSrc(photo.file_path);
+            } catch {
+                return "";
+            }
+        }
+        return "";
+    }
+
+    function filteredBoxes(boxes: ObjectDetectionBox[], item: SmartCollection): ObjectDetectionBox[] {
+        if (item.kind !== "object" || !item.label) return boxes;
+        return boxes.filter((box) => box.label.toLowerCase() === item.label!.toLowerCase());
+    }
+
+    function filteredLabels(labels: VisualIndexLabel[], item: SmartCollection): VisualIndexLabel[] {
+        if (item.kind === "object" && item.label) {
+            return labels.filter((label) => label.label.toLowerCase() === item.label!.toLowerCase());
+        }
+        return labels.filter((label) => label.source === "model" || label.kind === item.kind).slice(0, 6);
+    }
+
+    function confidence(value: number): string {
+        return `${Math.round(value * 100)}%`;
+    }
+</script>
+
+<div class="fixed inset-0 z-[100] bg-black/80 p-3 text-white backdrop-blur-md md:p-5">
+    <section class="mx-auto grid h-full max-w-7xl grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-xl border border-white/15 bg-zinc-950 shadow-2xl">
+        <header class="flex items-center gap-3 border-b border-white/10 bg-white/[0.04] px-4 py-3">
+            <div class="grid h-9 w-9 place-items-center rounded-lg bg-white/10 text-cyan-200">
+                <ScanSearch size={18} />
+            </div>
+            <div class="min-w-0">
+                <div class="text-[10px] font-bold uppercase tracking-normal text-cyan-200">Detection Map</div>
+                <h2 class="truncate text-sm font-semibold">{collection.name}</h2>
+            </div>
+            <div class="ml-auto hidden text-xs text-white/55 sm:block">
+                {collectionPhotos.length} frames / {activeBoxes.length} visible boxes
+            </div>
+            <button
+                class="grid h-8 w-8 place-items-center rounded-md bg-white/10 text-white/70 transition-colors hover:bg-white/15 hover:text-white"
+                onclick={onClose}
+                aria-label="Close detection debug view"
+                title="Close"
+            >
+                <X size={16} />
+            </button>
+        </header>
+
+        <div class="grid min-h-0 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_20rem]">
+            <div class="min-h-0 overflow-auto bg-black p-4">
+                <div class="flex min-h-full items-center justify-center">
+                    {#if activePhoto && previewSrc(activePhoto)}
+                        <div class="relative inline-block max-h-full max-w-full">
+                            <img
+                                class="block max-h-[calc(100vh-9rem)] max-w-full rounded-lg object-contain shadow-2xl"
+                                src={previewSrc(activePhoto)}
+                                alt={activePhoto.file_name}
+                            />
+                            {#each activeBoxes as box (box.id)}
+                                <div
+                                    class="pointer-events-none absolute rounded-md border-2 border-cyan-300 bg-cyan-300/10 shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+                                    style={`left:${box.box.x}%;top:${box.box.y}%;width:${box.box.width}%;height:${box.box.height}%`}
+                                >
+                                    <span class="absolute left-0 top-0 -translate-y-full rounded-t-md bg-cyan-300 px-1.5 py-0.5 text-[10px] font-bold text-black shadow-sm">
+                                        {box.label} {confidence(box.confidence)}
+                                    </span>
+                                </div>
+                            {/each}
+                        </div>
+                    {:else}
+                        <div class="grid h-64 w-full max-w-lg place-items-center rounded-xl border border-white/10 bg-white/[0.03] text-white/50">
+                            <div class="flex flex-col items-center gap-2">
+                                <ImageOff size={30} />
+                                <span class="text-sm">No preview available</span>
+                            </div>
+                        </div>
+                    {/if}
+                </div>
+            </div>
+
+            <aside class="min-h-0 overflow-y-auto border-l border-white/10 bg-white/[0.04] p-4">
+                <div class="mb-4">
+                    <div class="mb-2 flex items-center gap-2 text-xs font-bold uppercase text-white/70">
+                        <Bug size={14} />
+                        Why It Matched
+                    </div>
+                    {#if activeLabels.length > 0}
+                        <div class="space-y-2">
+                            {#each activeLabels as label}
+                                <div class="rounded-lg border border-white/10 bg-black/20 p-3">
+                                    <div class="flex items-center justify-between gap-2">
+                                        <span class="text-sm font-semibold">{label.label}</span>
+                                        <span class="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-bold text-white/75">{confidence(label.confidence)}</span>
+                                    </div>
+                                    {#if label.reason}
+                                        <p class="mt-1 text-xs leading-5 text-white/60">{label.reason}</p>
+                                    {/if}
+                                    {#if label.evidence?.length}
+                                        <div class="mt-2 flex flex-wrap gap-1">
+                                            {#each label.evidence as evidence}
+                                                <span class="rounded-full bg-white/10 px-2 py-0.5 text-[10px] text-white/65">{evidence}</span>
+                                            {/each}
+                                        </div>
+                                    {/if}
+                                </div>
+                            {/each}
+                        </div>
+                    {:else}
+                        <div class="rounded-lg border border-white/10 bg-black/20 p-3 text-xs leading-5 text-white/60">
+                            No detector boxes were stored for this frame yet. Re-index the library after the local model finishes downloading.
+                        </div>
+                    {/if}
+                </div>
+
+                <div class="mb-3 text-xs font-bold uppercase text-white/70">Frames</div>
+                <div class="grid grid-cols-3 gap-2">
+                    {#each collectionPhotos as photo (photo.id)}
+                        <button
+                            class="relative aspect-square overflow-hidden rounded-md border transition-colors {photo.id === activePhoto?.id ? 'border-cyan-300' : 'border-white/10 hover:border-white/35'}"
+                            onclick={() => (activePhotoId = photo.id)}
+                            title={photo.file_name}
+                        >
+                            {#if previewSrc(photo)}
+                                <img class="h-full w-full object-cover" src={previewSrc(photo)} alt={photo.file_name} loading="lazy" />
+                            {:else}
+                                <div class="grid h-full w-full place-items-center bg-white/5 text-white/35">
+                                    <ImageOff size={16} />
+                                </div>
+                            {/if}
+                            {#if (visualIndex[photo.id]?.detections?.length ?? 0) > 0}
+                                <span class="absolute bottom-1 right-1 rounded bg-black/70 px-1 text-[10px] font-bold text-cyan-200">
+                                    {visualIndex[photo.id]?.detections?.length}
+                                </span>
+                            {/if}
+                        </button>
+                    {/each}
+                </div>
+            </aside>
+        </div>
+    </section>
+</div>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,16 +1,32 @@
 <script lang="ts">
+    import { convertFileSrc } from "@tauri-apps/api/core";
     import { photoStore, stats } from "../stores/photoStore.ts";
     import { HologramAPI } from "../api.ts";
-    import type { ExifData, Photo, PhotoFilter, SavedSearch, SmartCollection, ThumbnailReady, VisualIndexProgress } from "../types.ts";
+    import type {
+        ExifData,
+        ObjectDetectionModelManifest,
+        ObjectDetectionModelState,
+        Photo,
+        PhotoFilter,
+        SavedSearch,
+        SmartCollection,
+        ThumbnailReady,
+        VisualIndexProgress,
+    } from "../types.ts";
     import ExportPanel from "./ExportPanel.svelte";
     import {
         BarChart3,
         Bookmark,
+        Bug,
         Camera,
         Check,
+        Download,
         Filter,
         FolderOpen,
         Plus,
+        Power,
+        ScanSearch,
+        ShieldCheck,
         Sparkles,
         Star,
         Trash2,
@@ -29,11 +45,16 @@
         smartCollectionsEnabled?: boolean;
         smartCollectionsIndexing?: boolean;
         visualIndexProgress?: VisualIndexProgress;
+        objectDetectionModelState?: ObjectDetectionModelState;
+        objectDetectionModelManifest?: ObjectDetectionModelManifest;
         onFilter: (filter: PhotoFilter) => void;
         onSavedSearchSelect?: (id: string) => void;
         onSavedSearchDelete?: (id: string) => void;
         onSmartCollectionSelect?: (id: string | null) => void;
         onSmartCollectionsTitleClick?: () => void;
+        onSmartCollectionDebug?: (id: string) => void;
+        onSmartCollectionsDisable?: () => void;
+        onObjectDetectionModelDelete?: () => void;
     }
 
     let {
@@ -47,11 +68,16 @@
         smartCollectionsEnabled = false,
         smartCollectionsIndexing = false,
         visualIndexProgress = { current: 0, total: 0 },
+        objectDetectionModelState,
+        objectDetectionModelManifest,
         onFilter,
         onSavedSearchSelect = () => {},
         onSavedSearchDelete = () => {},
         onSmartCollectionSelect = () => {},
         onSmartCollectionsTitleClick = () => {},
+        onSmartCollectionDebug = () => {},
+        onSmartCollectionsDisable = () => {},
+        onObjectDetectionModelDelete = () => {},
     }: Props = $props();
 
     let activeFilter = $state<PhotoFilter>({});
@@ -67,6 +93,16 @@
         allPhotos.filter((photo) => photo.flag === "pick" || photo.flag === "reject" || (photo.rating ?? 0) > 0).length,
     );
     const reviewPct = $derived(allPhotos.length ? Math.round((reviewedCount / allPhotos.length) * 100) : 0);
+    const modelReady = $derived(objectDetectionModelState?.status === "ready");
+    const modelStatusText = $derived(
+        objectDetectionModelState?.status === "ready"
+            ? "Local model ready"
+            : objectDetectionModelState?.status === "downloading"
+                ? "Downloading model"
+                : objectDetectionModelState?.status === "error"
+                    ? "Model needs attention"
+                    : "Model not downloaded",
+    );
 
     const selectFields: { exifKey: keyof ExifData; label: string; filterKey: keyof PhotoFilter }[] = [
         { exifKey: "camera_model", label: "Camera Model", filterKey: "camera_model" },
@@ -282,6 +318,41 @@
     function progressWidth(percent: number): string {
         return `${Math.max(0, Math.min(100, percent))}%`;
     }
+
+    function previewSrc(photo: Photo | undefined): string {
+        if (!photo) return "";
+        if (photo.thumbnail) {
+            const mime = photo.thumbnail.startsWith("iVBOR") ? "image/png" : "image/jpeg";
+            return `data:${mime};base64,${photo.thumbnail}`;
+        }
+        if (["JPEG", "JPG", "PNG", "WEBP", "GIF"].includes(photo.file_type.toUpperCase())) {
+            try {
+                return convertFileSrc(photo.file_path);
+            } catch {
+                return "";
+            }
+        }
+        return "";
+    }
+
+    function collectionPreviewPhotos(collection: SmartCollection): Photo[] {
+        const ids = collection.cover_photo_ids?.length ? collection.cover_photo_ids : collection.photo_ids;
+        return ids.map((id) => allPhotos.find((photo) => photo.id === id)).filter(Boolean).slice(0, 4) as Photo[];
+    }
+
+    function kindLabel(kind: SmartCollection["kind"]): string {
+        if (kind === "memory") return "Memory";
+        if (kind === "object") return "Objects";
+        if (kind === "scene") return "Scenes";
+        return "Looks";
+    }
+
+    function collectionGradientClass(kind: SmartCollection["kind"]): string {
+        if (kind === "memory") return "bg-gradient-to-br from-rose-500 to-amber-400";
+        if (kind === "object") return "bg-gradient-to-br from-sky-500 to-cyan-400";
+        if (kind === "scene") return "bg-gradient-to-br from-emerald-500 to-teal-400";
+        return "bg-gradient-to-br from-violet-500 to-fuchsia-400";
+    }
 </script>
 
 <aside class="flex h-screen w-80 shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
@@ -368,7 +439,7 @@
                     <Sparkles size={14} class="text-primary" />
                     <button
                         class="text-left text-xs font-bold uppercase text-foreground transition-colors hover:text-primary"
-                        onclick={smartCollectionsEnabled ? undefined : onSmartCollectionsTitleClick}
+                        onclick={onSmartCollectionsTitleClick}
                     >
                         Smart Collections
                     </button>
@@ -383,11 +454,18 @@
 
                 {#if !smartCollectionsEnabled}
                     <button
-                        class="flex w-full items-center justify-between gap-2 rounded-md border border-dashed border-border bg-card px-3 py-2 text-left text-xs text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
+                        class="group w-full overflow-hidden rounded-lg border border-dashed border-border bg-card text-left transition-colors hover:border-primary"
                         onclick={onSmartCollectionsTitleClick}
                     >
-                        <span class="font-semibold">Enable visual index</span>
-                        <Sparkles size={14} />
+                        <div class="flex items-center gap-3 p-3">
+                            <div class="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
+                                <Download size={16} />
+                            </div>
+                            <div class="min-w-0">
+                                <div class="text-xs font-semibold text-foreground">Download local detector</div>
+                                <div class="truncate text-[10px] text-muted-foreground">{objectDetectionModelManifest?.name ?? "Object detector"} / {modelStatusText}</div>
+                            </div>
+                        </div>
                     </button>
                 {:else}
                     {#if smartCollectionsIndexing}
@@ -399,6 +477,41 @@
                         </div>
                     {/if}
 
+                    <div class="mb-3 rounded-lg border border-border bg-card p-3">
+                        <div class="flex items-center gap-2">
+                            <ShieldCheck size={14} class={modelReady ? "text-pick" : "text-muted-foreground"} />
+                            <div class="min-w-0 flex-1">
+                                <div class="truncate text-xs font-semibold text-foreground">{modelStatusText}</div>
+                                <div class="truncate text-[10px] text-muted-foreground">{objectDetectionModelManifest?.name ?? "Object detector"}</div>
+                            </div>
+                            <button
+                                class="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                                onclick={onSmartCollectionsTitleClick}
+                                title="Manage Smart Collections"
+                            >
+                                <ScanSearch size={13} />
+                            </button>
+                        </div>
+                        <div class="mt-2 flex gap-1">
+                            <button
+                                class="inline-flex h-7 flex-1 items-center justify-center gap-1 rounded-md bg-secondary px-2 text-[10px] font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                                onclick={onSmartCollectionsDisable}
+                                title="Disable Smart Collections"
+                            >
+                                <Power size={11} />
+                                Disable
+                            </button>
+                            <button
+                                class="inline-flex h-7 flex-1 items-center justify-center gap-1 rounded-md bg-secondary px-2 text-[10px] font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-reject"
+                                onclick={onObjectDetectionModelDelete}
+                                title="Delete local detector state"
+                            >
+                                <Trash2 size={11} />
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+
                     <div class="space-y-1">
                         <button
                             class="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors {activeSmartCollectionId == null ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}"
@@ -408,21 +521,56 @@
                             <span class="tabular-nums">{allPhotos.length}</span>
                         </button>
                         {#each smartCollections.slice(0, 12) as collection (collection.id)}
-                            <button
-                                class="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors {activeSmartCollectionId === collection.id ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}"
-                                onclick={() => onSmartCollectionSelect(collection.id)}
-                                title={collection.detail}
-                            >
-                                <span class="min-w-0">
-                                    <span class="block truncate font-semibold">{collection.name}</span>
-                                    <span class="block truncate text-[10px] opacity-75">{collection.detail}</span>
-                                </span>
-                                <span class="shrink-0 tabular-nums">{collection.photo_ids.length}</span>
-                            </button>
+                            {@const previews = collectionPreviewPhotos(collection)}
+                            <div class="group overflow-hidden rounded-lg border border-border bg-card transition-colors hover:border-primary/60">
+                                <button
+                                    class="relative block h-24 w-full overflow-hidden text-left"
+                                    onclick={() => onSmartCollectionSelect(collection.id)}
+                                    title={collection.detail}
+                                >
+                                    {#if previews.length > 0}
+                                        <div class="grid h-full grid-cols-2 grid-rows-2">
+                                            {#each previews as photo (photo.id)}
+                                                {#if previewSrc(photo)}
+                                                    <img class="h-full w-full object-cover" src={previewSrc(photo)} alt={photo.file_name} loading="lazy" />
+                                                {:else}
+                                                    <div class="bg-secondary"></div>
+                                                {/if}
+                                            {/each}
+                                        </div>
+                                    {:else}
+                                        <div class={`h-full ${collectionGradientClass(collection.kind)}`}></div>
+                                    {/if}
+                                    <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/15 to-transparent"></div>
+                                    <div class="absolute inset-x-0 bottom-0 p-2 text-white">
+                                        <div class="flex items-end justify-between gap-2">
+                                            <div class="min-w-0">
+                                                <div class="truncate text-xs font-bold">{collection.name}</div>
+                                                <div class="truncate text-[10px] text-white/75">{kindLabel(collection.kind)} / {collection.detail}</div>
+                                            </div>
+                                            <span class="rounded-full bg-white/20 px-1.5 py-0.5 text-[10px] font-bold tabular-nums">{collection.photo_ids.length}</span>
+                                        </div>
+                                    </div>
+                                    {#if activeSmartCollectionId === collection.id}
+                                        <div class="absolute inset-0 rounded-lg ring-2 ring-primary"></div>
+                                    {/if}
+                                </button>
+                                <div class="flex items-center justify-between gap-2 border-t border-border px-2 py-1.5">
+                                    <span class="truncate text-[10px] text-muted-foreground">{collection.label ?? kindLabel(collection.kind)}</span>
+                                    <button
+                                        class="inline-flex h-6 items-center gap-1 rounded-md bg-secondary px-2 text-[10px] font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                                        onclick={() => onSmartCollectionDebug(collection.id)}
+                                        title="Show detection boxes"
+                                    >
+                                        <Bug size={11} />
+                                        Boxes
+                                    </button>
+                                </div>
+                            </div>
                         {/each}
                         {#if !smartCollectionsIndexing && smartCollections.length === 0}
                             <div class="rounded-md bg-card px-3 py-2 text-xs text-muted-foreground">
-                                No visual collections yet.
+                                No object collections yet.
                             </div>
                         {/if}
                     </div>

--- a/src/lib/objectDetectionModel.ts
+++ b/src/lib/objectDetectionModel.ts
@@ -1,0 +1,274 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+import type {
+  ObjectDetectionBox,
+  ObjectDetectionModelManifest,
+  ObjectDetectionModelProgress,
+  ObjectDetectionModelState,
+  Photo,
+} from "./types.ts";
+
+const MODEL_STATE_KEY = "hologram.objectDetectionModel.state";
+const MODEL_CACHE_KEY = "hologram-object-detection-models";
+
+export const objectDetectionModelManifest: ObjectDetectionModelManifest = {
+  id: "xenova-yolos-tiny-q8",
+  name: "YOLOS Tiny",
+  repository: "Xenova/yolos-tiny",
+  version: "main/q8",
+  source_name: "Hugging Face / Xenova YOLOS Tiny",
+  source_url: "https://huggingface.co/Xenova/yolos-tiny",
+  download_url: "https://huggingface.co/Xenova/yolos-tiny/resolve/main/onnx/model_quantized.onnx",
+  approximate_size_bytes: 9_700_000,
+  license: "Apache-2.0 upstream model license",
+  dtype: "q8",
+  storage_label: "Transformers.js browser model cache / hologram-object-detection-models",
+};
+
+type Detector = (image: string, options: { threshold: number; percentage: true }) => Promise<RawDetection[]>;
+
+type RawDetection = {
+  label: string;
+  score: number;
+  box: {
+    xmin: number;
+    ymin: number;
+    xmax: number;
+    ymax: number;
+  };
+};
+
+type TransformersProgress = {
+  status: "initiate" | "download" | "progress" | "done" | "ready" | "progress_total";
+  file?: string;
+  loaded?: number;
+  total?: number;
+  progress?: number;
+};
+
+const browserPreviewTypes = new Set(["JPEG", "JPG", "PNG", "WEBP", "GIF"]);
+let detectorPromise: Promise<Detector> | null = null;
+
+const defaultState: ObjectDetectionModelState = {
+  status: "not_downloaded",
+  manifest_id: objectDetectionModelManifest.id,
+  version: objectDetectionModelManifest.version,
+};
+
+function canUseBrowserStorage(): boolean {
+  return typeof localStorage !== "undefined";
+}
+
+function persistObjectDetectionModelState(state: ObjectDetectionModelState) {
+  if (!canUseBrowserStorage()) return;
+  localStorage.setItem(MODEL_STATE_KEY, JSON.stringify(state));
+}
+
+function progress(
+  phase: ObjectDetectionModelProgress["phase"],
+  receivedBytes: number,
+  totalBytes = objectDetectionModelManifest.approximate_size_bytes,
+): ObjectDetectionModelProgress {
+  const safeTotal = totalBytes > 0 ? totalBytes : objectDetectionModelManifest.approximate_size_bytes;
+  return {
+    phase,
+    received_bytes: receivedBytes,
+    total_bytes: safeTotal,
+    percent: Math.max(0, Math.min(100, Math.round((receivedBytes / safeTotal) * 100))),
+  };
+}
+
+function dataUrlForPhoto(photo: Photo): string {
+  if (photo.thumbnail) {
+    const mime = photo.thumbnail.startsWith("iVBOR") ? "image/png" : "image/jpeg";
+    return `data:${mime};base64,${photo.thumbnail}`;
+  }
+  if (browserPreviewTypes.has(photo.file_type.toUpperCase())) {
+    try {
+      return convertFileSrc(photo.file_path);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+async function cachedModelPresent(): Promise<boolean> {
+  if (typeof caches === "undefined") return false;
+  try {
+    const cache = await caches.open(MODEL_CACHE_KEY);
+    const keys = await cache.keys();
+    return keys.some((request) => (
+      request.url.includes(objectDetectionModelManifest.repository) ||
+      request.url.includes("model_quantized.onnx") ||
+      request.url.includes("preprocessor_config.json")
+    ));
+  } catch {
+    return false;
+  }
+}
+
+function toPercent(value: number): number {
+  const percent = value <= 1 ? value * 100 : value;
+  return Math.max(0, Math.min(100, percent));
+}
+
+function normalizeBox(detection: RawDetection, index: number): ObjectDetectionBox {
+  const x0 = toPercent(detection.box.xmin);
+  const y0 = toPercent(detection.box.ymin);
+  const x1 = toPercent(detection.box.xmax);
+  const y1 = toPercent(detection.box.ymax);
+  return {
+    id: `${objectDetectionModelManifest.id}-${detection.label}-${index}`,
+    label: titleCaseLabel(detection.label),
+    confidence: detection.score,
+    source: "model",
+    model_id: objectDetectionModelManifest.id,
+    box: {
+      x: Math.min(x0, x1),
+      y: Math.min(y0, y1),
+      width: Math.max(1, Math.abs(x1 - x0)),
+      height: Math.max(1, Math.abs(y1 - y0)),
+    },
+  };
+}
+
+function titleCaseLabel(label: string): string {
+  return label.replace(/[_-]+/g, " ").replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function toModelProgress(info: TransformersProgress): ObjectDetectionModelProgress | null {
+  if (info.status === "ready") {
+    return progress("ready", objectDetectionModelManifest.approximate_size_bytes);
+  }
+  if (info.status === "progress_total" || info.status === "progress") {
+    return progress(
+      "downloading",
+      info.loaded ?? 0,
+      info.total ?? objectDetectionModelManifest.approximate_size_bytes,
+    );
+  }
+  if (info.status === "download") return progress("downloading", 0);
+  if (info.status === "done") return progress("storing", objectDetectionModelManifest.approximate_size_bytes);
+  if (info.status === "initiate") return progress("requesting", 0);
+  return null;
+}
+
+async function loadDetector(
+  onProgress?: (next: ObjectDetectionModelProgress) => void,
+  allowDownload = false,
+): Promise<Detector> {
+  if (!detectorPromise) {
+    detectorPromise = (async () => {
+      const { pipeline, env } = await import("@huggingface/transformers");
+      env.allowRemoteModels = allowDownload;
+      env.useBrowserCache = true;
+      env.useCustomCache = false;
+      env.cacheKey = MODEL_CACHE_KEY;
+
+      return await pipeline("object-detection", objectDetectionModelManifest.repository, {
+        dtype: objectDetectionModelManifest.dtype as "q8",
+        local_files_only: !allowDownload,
+        progress_callback: (info: TransformersProgress) => {
+          const next = toModelProgress(info);
+          if (next) onProgress?.(next);
+        },
+      }) as Detector;
+    })();
+  }
+  return detectorPromise;
+}
+
+export function formatModelBytes(bytes: number): string {
+  if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(bytes >= 10_000_000 ? 0 : 1)} MB`;
+  if (bytes >= 1_000) return `${Math.round(bytes / 1_000)} KB`;
+  return `${bytes} bytes`;
+}
+
+export function loadObjectDetectionModelState(): ObjectDetectionModelState {
+  if (!canUseBrowserStorage()) return defaultState;
+  try {
+    const raw = localStorage.getItem(MODEL_STATE_KEY);
+    if (!raw) return defaultState;
+    const state = JSON.parse(raw) as ObjectDetectionModelState;
+    if (
+      state.manifest_id !== objectDetectionModelManifest.id ||
+      state.version !== objectDetectionModelManifest.version
+    ) {
+      return defaultState;
+    }
+    return state;
+  } catch {
+    return defaultState;
+  }
+}
+
+export async function validateObjectDetectionModelState(): Promise<ObjectDetectionModelState> {
+  const state = loadObjectDetectionModelState();
+  if (state.status !== "ready") return state;
+  if (await cachedModelPresent()) return state;
+
+  const missingModel: ObjectDetectionModelState = {
+    ...defaultState,
+    last_error: "The local object detection model cache is missing.",
+  };
+  persistObjectDetectionModelState(missingModel);
+  return missingModel;
+}
+
+export async function downloadObjectDetectionModel(
+  onProgress: (next: ObjectDetectionModelProgress) => void,
+): Promise<ObjectDetectionModelState> {
+  const downloading: ObjectDetectionModelState = {
+    ...defaultState,
+    status: "downloading",
+  };
+  persistObjectDetectionModelState(downloading);
+  onProgress(progress("requesting", 0));
+
+  try {
+    await loadDetector(onProgress, true);
+    const ready: ObjectDetectionModelState = {
+      status: "ready",
+      manifest_id: objectDetectionModelManifest.id,
+      version: objectDetectionModelManifest.version,
+      downloaded_at: new Date().toISOString(),
+      bytes: objectDetectionModelManifest.approximate_size_bytes,
+      cache_key: objectDetectionModelManifest.repository,
+    };
+    persistObjectDetectionModelState(ready);
+    onProgress(progress("ready", ready.bytes ?? objectDetectionModelManifest.approximate_size_bytes));
+    return ready;
+  } catch (error) {
+    detectorPromise = null;
+    const failed: ObjectDetectionModelState = {
+      ...defaultState,
+      status: "error",
+      last_error: error instanceof Error ? error.message : String(error),
+    };
+    persistObjectDetectionModelState(failed);
+    onProgress({ ...progress("error", 0), percent: 0 });
+    throw error;
+  }
+}
+
+export async function detectObjectsInPhoto(photo: Photo): Promise<ObjectDetectionBox[]> {
+  const src = dataUrlForPhoto(photo);
+  if (!src) return [];
+  const detector = await loadDetector(undefined, false);
+  const output = await detector(src, { threshold: 0.5, percentage: true });
+  return output
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 12)
+    .map((detection, index) => normalizeBox(detection, index));
+}
+
+export async function deleteObjectDetectionModel(): Promise<ObjectDetectionModelState> {
+  detectorPromise = null;
+  if (typeof caches !== "undefined") {
+    await caches.delete(MODEL_CACHE_KEY);
+  }
+  if (canUseBrowserStorage()) {
+    localStorage.removeItem(MODEL_STATE_KEY);
+  }
+  return defaultState;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,28 +101,84 @@ export interface SavedSearch {
 export interface SmartCollection {
   id: string;
   name: string;
-  kind: "object" | "scene" | "visual";
+  kind: "memory" | "object" | "scene" | "visual";
   detail: string;
   photo_ids: string[];
+  cover_photo_ids?: string[];
+  confidence?: number;
+  label?: string;
+  accent?: string;
 }
 
 export interface VisualIndexLabel {
   label: string;
-  kind: "object" | "scene" | "visual";
+  kind: "memory" | "object" | "scene" | "visual";
   confidence: number;
-  source: "image" | "metadata";
+  source: "image" | "metadata" | "model";
+  reason?: string;
+  evidence?: string[];
+  boxes?: ObjectDetectionBox[];
+}
+
+export interface ObjectDetectionBox {
+  id: string;
+  label: string;
+  confidence: number;
+  source: "model";
+  model_id: string;
+  box: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
 }
 
 export interface VisualIndexEntry {
   photo_id: string;
   labels: VisualIndexLabel[];
+  detections?: ObjectDetectionBox[];
   indexed_at: string;
+  detector_model_id?: string;
 }
 
 export interface VisualIndexProgress {
   current: number;
   total: number;
   current_file?: string;
+}
+
+export interface ObjectDetectionModelManifest {
+  id: string;
+  name: string;
+  repository: string;
+  version: string;
+  source_name: string;
+  source_url: string;
+  download_url: string;
+  approximate_size_bytes: number;
+  license: string;
+  dtype: string;
+  storage_label: string;
+}
+
+export type ObjectDetectionModelStatus = "not_downloaded" | "downloading" | "ready" | "error";
+
+export interface ObjectDetectionModelState {
+  status: ObjectDetectionModelStatus;
+  manifest_id: string;
+  version: string;
+  downloaded_at?: string;
+  bytes?: number;
+  cache_key?: string;
+  last_error?: string;
+}
+
+export interface ObjectDetectionModelProgress {
+  phase: "requesting" | "downloading" | "storing" | "ready" | "error";
+  received_bytes: number;
+  total_bytes: number;
+  percent: number;
 }
 
 export interface ExportOptions {

--- a/src/lib/visualIndex.ts
+++ b/src/lib/visualIndex.ts
@@ -1,5 +1,11 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
-import type { Photo, VisualIndexEntry, VisualIndexLabel, VisualIndexProgress } from "./types.ts";
+import type { ObjectDetectionBox, Photo, VisualIndexEntry, VisualIndexLabel, VisualIndexProgress } from "./types.ts";
+
+type VisualIndexOptions = {
+  detectorReady?: boolean;
+  detectorModelId?: string;
+  detectObjects?: (photo: Photo) => Promise<ObjectDetectionBox[]>;
+};
 
 type LabelSeed = {
   label: string;
@@ -37,27 +43,71 @@ function addLabel(labels: Map<string, VisualIndexLabel>, label: VisualIndexLabel
   }
 }
 
+function addDetectionLabels(labels: Map<string, VisualIndexLabel>, detections: ObjectDetectionBox[]) {
+  const grouped = new Map<string, ObjectDetectionBox[]>();
+  for (const detection of detections) {
+    grouped.set(detection.label, [...(grouped.get(detection.label) ?? []), detection]);
+  }
+
+  for (const [label, boxes] of grouped) {
+    const best = boxes.reduce((max, box) => Math.max(max, box.confidence), 0);
+    addLabel(labels, {
+      label,
+      kind: "object",
+      confidence: best,
+      source: "model",
+      reason: `The local object detector found ${boxes.length} ${label.toLowerCase()} ${boxes.length === 1 ? "box" : "boxes"} in the frame.`,
+      evidence: boxes.map((box) => `${Math.round(box.confidence * 100)}% ${box.label}`).slice(0, 4),
+      boxes,
+    });
+  }
+}
+
 function metadataLabels(photo: Photo): VisualIndexLabel[] {
   const text = photoText(photo);
   const labels = new Map<string, VisualIndexLabel>();
   for (const seed of metadataSeeds) {
-    if (seed.tokens.some((token) => text.includes(token))) {
+    const matches = seed.tokens.filter((token) => text.includes(token));
+    if (matches.length > 0) {
       addLabel(labels, {
         label: seed.label,
         kind: seed.kind,
         confidence: 0.72,
         source: "metadata",
+        reason: "Matched filename, tags, or notes that describe the subject.",
+        evidence: matches.slice(0, 3),
       });
     }
   }
   if ((photo.exif.focal_length ?? 0) >= 85) {
-    addLabel(labels, { label: "Telephoto", kind: "visual", confidence: 0.64, source: "metadata" });
+    addLabel(labels, {
+      label: "Telephoto",
+      kind: "visual",
+      confidence: 0.64,
+      source: "metadata",
+      reason: "The EXIF focal length is in a telephoto range.",
+      evidence: [`${Math.round(photo.exif.focal_length ?? 0)}mm`],
+    });
   }
   if ((photo.exif.aperture ?? 99) <= 2.8) {
-    addLabel(labels, { label: "Shallow Depth", kind: "visual", confidence: 0.62, source: "metadata" });
+    addLabel(labels, {
+      label: "Shallow Depth",
+      kind: "visual",
+      confidence: 0.62,
+      source: "metadata",
+      reason: "The EXIF aperture suggests a shallow depth of field.",
+      evidence: [`f/${(photo.exif.aperture ?? 0).toFixed(1)}`],
+    });
   }
   if ((photo.exif.iso ?? 0) >= 3200) {
-    addLabel(labels, { label: "Low Light", kind: "scene", confidence: 0.6, source: "metadata" });
+    addLabel(labels, {
+      label: "Low Light",
+      kind: "scene",
+      confidence: 0.6,
+      source: "metadata",
+      reason: "The EXIF ISO is high enough to suggest a dim scene.",
+      evidence: [`ISO ${photo.exif.iso}`],
+    });
   }
   return Array.from(labels.values());
 }
@@ -161,19 +211,46 @@ async function imageLabels(photo: Photo): Promise<VisualIndexLabel[]> {
   const labels = new Map<string, VisualIndexLabel>();
   const avgLuma = totalLuma / total;
   const avgSat = totalSat / total;
-  const addImageLabel = (label: string, kind: VisualIndexLabel["kind"], confidence: number) => {
-    addLabel(labels, { label, kind, confidence: Math.max(0.5, Math.min(0.95, confidence)), source: "image" });
+  const addImageLabel = (
+    label: string,
+    kind: VisualIndexLabel["kind"],
+    confidence: number,
+    reason: string,
+    evidence: string[],
+  ) => {
+    addLabel(labels, {
+      label,
+      kind,
+      confidence: Math.max(0.5, Math.min(0.95, confidence)),
+      source: "image",
+      reason,
+      evidence,
+    });
   };
 
-  if (blueTop / total > 0.16) addImageLabel("Sky", "scene", 0.64 + blueTop / total);
-  if (green / total > 0.22) addImageLabel("Foliage", "scene", 0.58 + green / total);
-  if (blueLower / total > 0.18) addImageLabel("Water", "scene", 0.55 + blueLower / total);
-  if (warm / total > 0.24) addImageLabel("Warm Light", "scene", 0.58 + warm / total);
-  if (dark / total > 0.5 || avgLuma < 72) addImageLabel("Low Light", "scene", 0.68);
-  if (bright / total > 0.58 && avgSat < 0.22) addImageLabel("Snow or Fog", "scene", 0.62);
-  if (lowSat / total > 0.78 && avgSat < 0.13) addImageLabel("Black and White", "visual", 0.76);
+  if (blueTop / total > 0.16) {
+    addImageLabel("Sky", "scene", 0.64 + blueTop / total, "The upper preview contains a strong blue region.", [`${Math.round((blueTop / total) * 100)}% upper-blue pixels`]);
+  }
+  if (green / total > 0.22) {
+    addImageLabel("Foliage", "scene", 0.58 + green / total, "The preview has a large green color cluster.", [`${Math.round((green / total) * 100)}% green pixels`]);
+  }
+  if (blueLower / total > 0.18) {
+    addImageLabel("Water", "scene", 0.55 + blueLower / total, "The lower preview contains a saturated blue region.", [`${Math.round((blueLower / total) * 100)}% lower-blue pixels`]);
+  }
+  if (warm / total > 0.24) {
+    addImageLabel("Warm Light", "scene", 0.58 + warm / total, "The preview contains a warm orange or red color cast.", [`${Math.round((warm / total) * 100)}% warm pixels`]);
+  }
+  if (dark / total > 0.5 || avgLuma < 72) {
+    addImageLabel("Low Light", "scene", 0.68, "The preview is predominantly dark.", [`average luma ${Math.round(avgLuma)}`]);
+  }
+  if (bright / total > 0.58 && avgSat < 0.22) {
+    addImageLabel("Snow or Fog", "scene", 0.62, "The preview is bright with low saturation.", [`${Math.round((bright / total) * 100)}% bright pixels`, `saturation ${avgSat.toFixed(2)}`]);
+  }
+  if (lowSat / total > 0.78 && avgSat < 0.13) {
+    addImageLabel("Black and White", "visual", 0.76, "The preview is almost entirely low saturation.", [`${Math.round((lowSat / total) * 100)}% low-saturation pixels`]);
+  }
   if ((photo.exif.width ?? 0) > 0 && (photo.exif.height ?? 0) > 0 && (photo.exif.height ?? 0) > (photo.exif.width ?? 0)) {
-    addImageLabel("Portrait Orientation", "visual", 0.82);
+    addImageLabel("Portrait Orientation", "visual", 0.82, "The EXIF dimensions are taller than wide.", [`${photo.exif.width} x ${photo.exif.height}`]);
   }
 
   return Array.from(labels.values());
@@ -196,6 +273,7 @@ export async function indexPhotoVisuals(
   photos: Photo[],
   onProgress: (progress: VisualIndexProgress) => void,
   existing: Record<string, VisualIndexEntry> = {},
+  options: VisualIndexOptions = {},
 ): Promise<Record<string, VisualIndexEntry>> {
   const next: Record<string, VisualIndexEntry> = { ...existing };
   const total = photos.length;
@@ -205,22 +283,37 @@ export async function indexPhotoVisuals(
     onProgress({ current: index, total, current_file: photo.file_name });
     await idleTick();
 
-    if (next[photo.id]) {
+    const existingEntry = next[photo.id];
+    if (
+      existingEntry &&
+      (!options.detectorReady || existingEntry.detector_model_id === options.detectorModelId)
+    ) {
       continue;
     }
 
     const labels = new Map<string, VisualIndexLabel>();
+    let detections: ObjectDetectionBox[] = [];
     for (const label of metadataLabels(photo)) addLabel(labels, label);
     try {
       for (const label of await imageLabels(photo)) addLabel(labels, label);
     } catch {
       // Unsupported formats or partially generated thumbnails can be retried in a later indexing pass.
     }
+    if (options.detectorReady && options.detectObjects) {
+      try {
+        detections = await options.detectObjects(photo);
+        addDetectionLabels(labels, detections);
+      } catch {
+        detections = [];
+      }
+    }
 
     next[photo.id] = {
       photo_id: photo.id,
       labels: Array.from(labels.values()).sort((a, b) => b.confidence - a.confidence),
+      detections,
       indexed_at: new Date().toISOString(),
+      detector_model_id: options.detectorReady ? options.detectorModelId : undefined,
     };
   }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,10 +13,31 @@
     import TimelineView from "../lib/components/TimelineView.svelte";
     import Sidebar from "../lib/components/Sidebar.svelte";
     import PhotoViewer from "../lib/components/PhotoViewer.svelte";
+    import DetectionDebugModal from "../lib/components/DetectionDebugModal.svelte";
     import { HologramAPI } from "../lib/api.ts";
     import { buildSmartCollections } from "../lib/collections.ts";
+    import {
+        deleteObjectDetectionModel,
+        detectObjectsInPhoto,
+        downloadObjectDetectionModel,
+        formatModelBytes,
+        loadObjectDetectionModelState,
+        objectDetectionModelManifest,
+        validateObjectDetectionModelState,
+    } from "../lib/objectDetectionModel.ts";
     import { indexPhotoVisuals } from "../lib/visualIndex.ts";
-    import type { CullFlag, Photo, PhotoFilter, SavedSearch, ThumbnailReady, VisualIndexEntry, VisualIndexProgress } from "../lib/types.ts";
+    import type {
+        CullFlag,
+        ObjectDetectionModelProgress,
+        ObjectDetectionModelState,
+        Photo,
+        PhotoFilter,
+        SavedSearch,
+        SmartCollection,
+        ThumbnailReady,
+        VisualIndexEntry,
+        VisualIndexProgress,
+    } from "../lib/types.ts";
     import {
         Bookmark,
         CalendarRange,
@@ -31,8 +52,10 @@
         Rows3,
         Search,
         Save,
+        ShieldCheck,
         Sparkles,
         Star,
+        Trash2,
         XCircle,
     } from "@lucide/svelte";
 
@@ -63,6 +86,16 @@
     let visualIndex = $state<Record<string, VisualIndexEntry>>({});
     let visualIndexProgress = $state<VisualIndexProgress>({ current: 0, total: 0 });
     let visualIndexLibraryKey = $state("");
+    let objectDetectionModelState = $state<ObjectDetectionModelState>(loadObjectDetectionModelState());
+    let objectDetectionModelProgress = $state<ObjectDetectionModelProgress>({
+        phase: "requesting",
+        received_bytes: 0,
+        total_bytes: objectDetectionModelManifest.approximate_size_bytes,
+        percent: 0,
+    });
+    let isObjectDetectionModelDownloading = $state(false);
+    let smartCollectionError = $state("");
+    let debugSmartCollection = $state<SmartCollection | null>(null);
     let searchTimer: ReturnType<typeof setTimeout> | undefined;
 
     const searchCache = new Map<string, { key: string; text: string }>();
@@ -75,7 +108,7 @@
         $displayPhotos.filter((photo) => (photo.flag ?? "none") === "none" && (photo.rating ?? 0) === 0).length,
     );
     const smartCollections = $derived(
-        smartCollectionsEnabled ? buildSmartCollections($photos, visualIndex) : [],
+        smartCollectionsEnabled && objectDetectionModelState.status === "ready" ? buildSmartCollections($photos, visualIndex) : [],
     );
     const gridTileSize = $derived(GRID_ZOOM_STEPS[gridZoomLevel] ?? GRID_ZOOM_STEPS[DEFAULT_GRID_ZOOM_LEVEL]);
     const maxGridZoomLevel = GRID_ZOOM_STEPS.length - 1;
@@ -85,6 +118,7 @@
         loadSmartCollectionState();
         loadGridPreferences();
         didLoadGridPreferences = true;
+        void refreshObjectDetectionModelState();
         if (import.meta.env.DEV) {
             (window as any).__photoStore__ = photoStore;
             const seedHandler = ((e: CustomEvent) => {
@@ -108,7 +142,13 @@
 
     $effect(() => {
         const ids = $photos.map((photo) => photo.id).join("|");
-        if (!smartCollectionsEnabled || !ids || isVisualIndexing || ids === visualIndexLibraryKey) return;
+        if (
+            !smartCollectionsEnabled ||
+            objectDetectionModelState.status !== "ready" ||
+            !ids ||
+            isVisualIndexing ||
+            ids === visualIndexLibraryKey
+        ) return;
         visualIndexLibraryKey = ids;
         void startVisualIndexing($photos);
     });
@@ -271,17 +311,42 @@
         }
     }
 
+    async function refreshObjectDetectionModelState() {
+        objectDetectionModelState = await validateObjectDetectionModelState();
+        if (objectDetectionModelState.status !== "ready" && smartCollectionsEnabled) {
+            smartCollectionsEnabled = false;
+            localStorage.removeItem("hologram.smartCollections.enabled");
+        }
+    }
+
     function persistVisualIndex(entries: Record<string, VisualIndexEntry>) {
         visualIndex = entries;
         localStorage.setItem("hologram.visualIndex", JSON.stringify(entries));
     }
 
     function openSmartCollectionsModal() {
-        if (smartCollectionsEnabled) return;
+        smartCollectionError = "";
         showSmartCollectionsModal = true;
     }
 
-    function enableSmartCollections() {
+    async function enableSmartCollections() {
+        if (isObjectDetectionModelDownloading) return;
+        smartCollectionError = "";
+        if (objectDetectionModelState.status !== "ready") {
+            isObjectDetectionModelDownloading = true;
+            try {
+                objectDetectionModelState = await downloadObjectDetectionModel((progress) => {
+                    objectDetectionModelProgress = progress;
+                });
+            } catch (error) {
+                smartCollectionError = error instanceof Error ? error.message : String(error);
+                objectDetectionModelState = loadObjectDetectionModelState();
+                return;
+            } finally {
+                isObjectDetectionModelDownloading = false;
+            }
+        }
+
         smartCollectionsEnabled = true;
         localStorage.setItem("hologram.smartCollections.enabled", "true");
         showSmartCollectionsModal = false;
@@ -290,6 +355,27 @@
             visualIndexLibraryKey = $photos.map((photo) => photo.id).join("|");
             void startVisualIndexing($photos);
         }
+    }
+
+    function disableSmartCollections() {
+        smartCollectionsEnabled = false;
+        activeSmartCollectionId = null;
+        showSmartCollectionsModal = false;
+        visualIndexLibraryKey = "";
+        localStorage.removeItem("hologram.smartCollections.enabled");
+        applyAllFilters();
+    }
+
+    async function deleteLocalObjectDetectionModel() {
+        disableSmartCollections();
+        objectDetectionModelState = await deleteObjectDetectionModel();
+        visualIndex = {};
+        localStorage.removeItem("hologram.visualIndex");
+    }
+
+    function openSmartCollectionDebug(id: string) {
+        const collection = smartCollections.find((item) => item.id === id);
+        if (collection) debugSmartCollection = collection;
     }
 
     async function startVisualIndexing(items: Photo[]) {
@@ -303,6 +389,11 @@
                     visualIndexProgress = progress;
                 },
                 visualIndex,
+                {
+                    detectorReady: objectDetectionModelState.status === "ready",
+                    detectorModelId: objectDetectionModelManifest.id,
+                    detectObjects: detectObjectsInPhoto,
+                },
             );
             persistVisualIndex(entries);
         } finally {
@@ -489,11 +580,16 @@
         smartCollectionsEnabled={smartCollectionsEnabled}
         smartCollectionsIndexing={isVisualIndexing}
         visualIndexProgress={visualIndexProgress}
+        objectDetectionModelState={objectDetectionModelState}
+        objectDetectionModelManifest={objectDetectionModelManifest}
         onFilter={handleSidebarFilter}
         onSavedSearchSelect={selectSavedSearch}
         onSavedSearchDelete={deleteSavedSearch}
         onSmartCollectionSelect={selectSmartCollection}
         onSmartCollectionsTitleClick={openSmartCollectionsModal}
+        onSmartCollectionDebug={openSmartCollectionDebug}
+        onSmartCollectionsDisable={disableSmartCollections}
+        onObjectDetectionModelDelete={deleteLocalObjectDetectionModel}
     />
 
     {#if !hasLibrary}
@@ -731,38 +827,109 @@
 
     {#if showSmartCollectionsModal}
         <div class="fixed inset-0 z-[90] grid place-items-center bg-black/60 px-4">
-            <section class="w-full max-w-md rounded-lg border border-border bg-card p-5 shadow-xl">
+            <section class="w-full max-w-lg rounded-xl border border-border bg-card p-5 shadow-xl">
                 <div class="mb-4 flex items-start gap-3">
                     <div class="grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
-                        <Sparkles size={20} />
+                        <ShieldCheck size={20} />
                     </div>
                     <div class="min-w-0">
-                        <h2 class="text-base font-semibold text-foreground">Enable Smart Collections?</h2>
+                        <h2 class="text-base font-semibold text-foreground">Enable Local Object Detection?</h2>
                         <p class="mt-1 text-sm text-muted-foreground">
-                            Hologram will index previews locally in the background to build visual collections.
+                            Hologram will download a small object detector, run it on this Mac, and build Memories-style Smart Collections from local detections.
                         </p>
                     </div>
                 </div>
-                <div class="rounded-md border border-border bg-background p-3 text-xs text-muted-foreground">
-                    The current index uses local thumbnail analysis and existing content labels. A bundled object detector can plug into the same index later.
+
+                <div class="overflow-hidden rounded-lg border border-border bg-background">
+                    <div class="grid grid-cols-[9rem_minmax(0,1fr)] border-b border-border text-xs">
+                        <div class="bg-secondary/60 px-3 py-2 font-semibold text-muted-foreground">Model</div>
+                        <div class="min-w-0 px-3 py-2 text-foreground">{objectDetectionModelManifest.name}</div>
+                    </div>
+                    <div class="grid grid-cols-[9rem_minmax(0,1fr)] border-b border-border text-xs">
+                        <div class="bg-secondary/60 px-3 py-2 font-semibold text-muted-foreground">Source</div>
+                        <a class="min-w-0 truncate px-3 py-2 text-primary hover:underline" href={objectDetectionModelManifest.source_url} target="_blank" rel="noreferrer">
+                            {objectDetectionModelManifest.source_name}
+                        </a>
+                    </div>
+                    <div class="grid grid-cols-[9rem_minmax(0,1fr)] border-b border-border text-xs">
+                        <div class="bg-secondary/60 px-3 py-2 font-semibold text-muted-foreground">Download</div>
+                        <div class="px-3 py-2 text-foreground">About {formatModelBytes(objectDetectionModelManifest.approximate_size_bytes)}</div>
+                    </div>
+                    <div class="grid grid-cols-[9rem_minmax(0,1fr)] border-b border-border text-xs">
+                        <div class="bg-secondary/60 px-3 py-2 font-semibold text-muted-foreground">License</div>
+                        <div class="px-3 py-2 text-foreground">{objectDetectionModelManifest.license}</div>
+                    </div>
+                    <div class="grid grid-cols-[9rem_minmax(0,1fr)] text-xs">
+                        <div class="bg-secondary/60 px-3 py-2 font-semibold text-muted-foreground">Storage</div>
+                        <div class="px-3 py-2 text-foreground">{objectDetectionModelManifest.storage_label}</div>
+                    </div>
                 </div>
-                <div class="mt-5 flex justify-end gap-2">
+
+                <div class="mt-3 rounded-lg border border-border bg-background p-3 text-xs leading-5 text-muted-foreground">
+                    No model download starts until you press the primary button. Smart Collections stay off if you cancel, and detected boxes are stored locally so the debug view can show why a photo matched a category.
+                </div>
+
+                {#if isObjectDetectionModelDownloading || objectDetectionModelState.status === "downloading"}
+                    <div class="mt-4">
+                        <div class="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+                            <span class="capitalize">{objectDetectionModelProgress.phase}</span>
+                            <span class="tabular-nums">{objectDetectionModelProgress.percent}%</span>
+                        </div>
+                        <div class="h-2 overflow-hidden rounded-full bg-secondary">
+                            <div class="h-full rounded-full bg-primary transition-[width]" style:width={`${objectDetectionModelProgress.percent}%`}></div>
+                        </div>
+                    </div>
+                {/if}
+
+                {#if smartCollectionError || objectDetectionModelState.status === "error"}
+                    <div class="mt-3 rounded-lg border border-reject/30 bg-reject/10 p-3 text-xs text-reject">
+                        {smartCollectionError || objectDetectionModelState.last_error}
+                    </div>
+                {/if}
+
+                <div class="mt-5 flex flex-wrap justify-end gap-2">
+                    {#if smartCollectionsEnabled}
+                        <button
+                            class="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-secondary px-3 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                            onclick={disableSmartCollections}
+                        >
+                            Disable
+                        </button>
+                        <button
+                            class="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-secondary px-3 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-reject"
+                            onclick={deleteLocalObjectDetectionModel}
+                        >
+                            <Trash2 size={15} />
+                            Delete Model
+                        </button>
+                    {/if}
                     <button
                         class="inline-flex h-9 items-center justify-center rounded-md bg-secondary px-3 text-sm font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                         onclick={() => (showSmartCollectionsModal = false)}
+                        disabled={isObjectDetectionModelDownloading}
                     >
                         Cancel
                     </button>
                     <button
-                        class="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                        class="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
                         onclick={enableSmartCollections}
+                        disabled={isObjectDetectionModelDownloading}
                     >
                         <Sparkles size={15} />
-                        Enable Indexing
+                        {objectDetectionModelState.status === "ready" ? "Enable Smart Collections" : "Download and Enable Local Object Detection"}
                     </button>
                 </div>
             </section>
         </div>
+    {/if}
+
+    {#if debugSmartCollection}
+        <DetectionDebugModal
+            collection={debugSmartCollection}
+            photos={$photos}
+            visualIndex={visualIndex}
+            onClose={() => (debugSmartCollection = null)}
+        />
     {/if}
 
     {#if $viewMode === "viewer"}


### PR DESCRIPTION
## Summary
- add a consent-gated local YOLOS Tiny object detector through Transformers.js
- require explicit download before Smart Collections can index content
- show Apple Photos-style smart collection cards and Memories-style generated groups
- add a Detection Map debug modal that overlays model bounding boxes on matched photos

## Details
Smart Collections now stay disabled until the user opens the modal and chooses "Download and Enable Local Object Detection." The modal discloses the model name, source, approximate size, license, storage location, and local-only behavior. Detection loads with remote downloads allowed only during that explicit action; later indexing uses local_files_only.

The visual index stores model detections, label reasons, evidence, and percentage-based bounding boxes. The sidebar can disable Smart Collections or delete the local model cache, and collection cards expose a "Boxes" action to explain why a photo matched.

## Validation
- bun run check
- bun run build
- cargo check
- git diff --check
- loaded Xenova/yolos-tiny q8 with Transformers.js
- Playwright/Chrome seeded checks for consent modal and Detection Map overlay
